### PR TITLE
Use gh api command instead of gh search command

### DIFF
--- a/query/issues.go
+++ b/query/issues.go
@@ -39,6 +39,9 @@ func (f *issueFetcherImpl) MyIssues() ([]usecase.Issue, error) {
 func searchIssueCommand() (*SearchQueryResponse, error) {
 	cmd := exec.Command("gh", "api", "/search/issues?q=assignee:@me+is:open+owner:wantedly+type:issue")
 	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute gh api command: %w", err)
+	}
 
 	var res SearchQueryResponse
 	if err := json.Unmarshal(output, &res); err != nil {

--- a/query/prs.go
+++ b/query/prs.go
@@ -31,7 +31,7 @@ func (f *prFetcherImpl) UnReviewedPrs() ([]usecase.PullRequest, error) {
 }
 
 // ChangesRequestedPrs returns a list of pull requests that are requested to change.
-func (f *prFetcherImpl) ChangesRequestedPrs() ([]usecase.PullRequest, error) {
+func (f *prFetcherImpl) ReviewedPrs() ([]usecase.PullRequest, error) {
 	b, err := searchChangeRequestedPRsCommand()
 	if err != nil {
 		return nil, fmt.Errorf("failed to search change requested prs: %w", err)
@@ -40,21 +40,6 @@ func (f *prFetcherImpl) ChangesRequestedPrs() ([]usecase.PullRequest, error) {
 	var prs []usecase.PullRequest
 	if err := json.Unmarshal(b, &prs); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal change requested prs: %w", err)
-	}
-
-	return prs, nil
-}
-
-// ReviewRequestedPrs returns a list of pull requests that are requested to review.
-func (f *prFetcherImpl) ReviewRequestedPrs() ([]usecase.PullRequest, error) {
-	b, err := searchReviewRequestedPRsCommand()
-	if err != nil {
-		return nil, fmt.Errorf("failed to search review requested prs: %w", err)
-	}
-
-	var prs []usecase.PullRequest
-	if err := json.Unmarshal(b, &prs); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal review requested prs: %w", err)
 	}
 
 	return prs, nil
@@ -93,18 +78,6 @@ func searchDraftPRsCommand() ([]byte, error) {
 // - review: changes_requested
 func searchChangeRequestedPRsCommand() ([]byte, error) {
 	cmd := exec.Command("gh", "search", "prs", "--owner", "wantedly", "--assignee", "@me", "--state", "open", "--review", "changes_requested", "--limit", "100", "--json", "url")
-	output, err := cmd.Output()
-	return output, err
-}
-
-// Search query:
-// - owner: wantedly
-// - assignee: @me
-// - state: open
-// - review: none
-// - draft: 0
-func searchReviewRequestedPRsCommand() ([]byte, error) {
-	cmd := exec.Command("gh", "search", "prs", "--owner", "wantedly", "--assignee", "@me", "--state", "open", "--review", "none", "--limit", "100", "--json", "url")
 	output, err := cmd.Output()
 	return output, err
 }

--- a/query/review_prs.go
+++ b/query/review_prs.go
@@ -17,14 +17,14 @@ func NewReviewPrFetcher() usecase.ReviewPrFetcher {
 
 // UnReviewedPrs returns a list of pull requests that are not reviewed.
 func (f *reviewPrFetcherImpl) UnReviewedPrs() ([]usecase.PullRequest, error) {
-	b, err := searchUnReviewedPRCommand()
+	res, err := searchUnReviewedPRCommand()
 	if err != nil {
 		return nil, fmt.Errorf("failed to search unreviewed prs: %w", err)
 	}
 
 	var prs []usecase.PullRequest
-	if err := json.Unmarshal(b, &prs); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal unreviewed prs: %w", err)
+	for _, item := range res.Items {
+		prs = append(prs, usecase.PullRequest{URL: item.HTMLURL})
 	}
 
 	return prs, nil
@@ -32,31 +32,29 @@ func (f *reviewPrFetcherImpl) UnReviewedPrs() ([]usecase.PullRequest, error) {
 
 // CommentedPrs returns a list of pull requests that are commented.
 func (f *reviewPrFetcherImpl) ReviewedPrs() ([]usecase.PullRequest, error) {
-	b, err := searchCommentedReviewPRCommand()
+	res, err := searchCommentedReviewPRCommand()
 	if err != nil {
 		return nil, fmt.Errorf("failed to search commented prs: %w", err)
 	}
 
 	var prs []usecase.PullRequest
-	if err := json.Unmarshal(b, &prs); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal commented prs: %w", err)
+	for _, item := range res.Items {
+		prs = append(prs, usecase.PullRequest{URL: item.HTMLURL})
 	}
-
-	// TODO: review-requested な PR が含まれている場合は除外する
 
 	return prs, nil
 }
 
 // ApprovedPrs returns a list of pull requests that are approved.
 func (f *reviewPrFetcherImpl) ApprovedPrs() ([]usecase.PullRequest, error) {
-	b, err := searchApprovedReviewPRCommand()
+	res, err := searchApprovedReviewPRCommand()
 	if err != nil {
 		return nil, fmt.Errorf("failed to search approved prs: %w", err)
 	}
 
 	var prs []usecase.PullRequest
-	if err := json.Unmarshal(b, &prs); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal approved prs: %w", err)
+	for _, item := range res.Items {
+		prs = append(prs, usecase.PullRequest{URL: item.HTMLURL})
 	}
 
 	return prs, nil
@@ -65,23 +63,36 @@ func (f *reviewPrFetcherImpl) ApprovedPrs() ([]usecase.PullRequest, error) {
 // Search query:
 // - owner: wantedly
 // - state: open
-// - review-requested: @me
-func searchUnReviewedPRCommand() ([]byte, error) {
-	cmd := exec.Command("gh", "search", "prs", "--owner", "wantedly", "--state", "open", "--review-requested", "@me", "--limit", "100", "--json", "url")
+// - review: none
+// - review-requested: igsr5
+func searchUnReviewedPRCommand() (*SearchQueryResponse, error) {
+	cmd := exec.Command("gh", "api", "/search/issues?q=is:open+owner:wantedly+type:pr+review-requested:igsr5")
 	output, err := cmd.Output()
-	return output, err
+
+	var res SearchQueryResponse
+	if err := json.Unmarshal(output, &res); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal unreviewed prs: %w", err)
+	}
+
+	return &res, err
 }
 
 // Search query:
 // - owner: wantedly
 // - state: open
-// - review: none
-// - reviewed-by: @me
-// - no-assignee: @me
-func searchCommentedReviewPRCommand() ([]byte, error) {
-	cmd := exec.Command("gh", "search", "prs", "--owner", "wantedly", "--state", "open", "--reviewed-by", "@me", "--review", "none", "--no-assignee", "@me", "--limit", "100", "--json", "url")
+// - reviewed-by: igsr5
+// - -assignee: igsr5
+// - -review: approved
+func searchCommentedReviewPRCommand() (*SearchQueryResponse, error) {
+	cmd := exec.Command("gh", "api", "/search/issues?q=is:open+owner:wantedly+type:pr+reviewed-by:igsr5+-assignee:igsr5+-review:approved")
 	output, err := cmd.Output()
-	return output, err
+
+	var res SearchQueryResponse
+	if err := json.Unmarshal(output, &res); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal commented prs: %w", err)
+	}
+
+	return &res, err
 }
 
 // Search query:
@@ -89,8 +100,16 @@ func searchCommentedReviewPRCommand() ([]byte, error) {
 // - state: open
 // - review: approved
 // - reviewed-by: @me
-func searchApprovedReviewPRCommand() ([]byte, error) {
-	cmd := exec.Command("gh", "search", "prs", "--owner", "wantedly", "--state", "open", "--reviewed-by", "@me", "--review", "approved", "--limit", "100", "--json", "url")
+func searchApprovedReviewPRCommand() (*SearchQueryResponse, error) {
+	// gh api "/search/issues?q=is:open+owner:wantedly+type:pr+reviewed-by:igsr5+-assignee:igsr5+review:approved"
+	cmd := exec.Command("gh", "api", "/search/issues?q=is:open+owner:wantedly+type:pr+reviewed-by:igsr5+-assignee:igsr5+review:approved")
+
 	output, err := cmd.Output()
-	return output, err
+
+	var res SearchQueryResponse
+	if err := json.Unmarshal(output, &res); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal approved prs: %w", err)
+	}
+
+	return &res, err
 }

--- a/query/review_prs.go
+++ b/query/review_prs.go
@@ -31,7 +31,7 @@ func (f *reviewPrFetcherImpl) UnReviewedPrs() ([]usecase.PullRequest, error) {
 }
 
 // CommentedPrs returns a list of pull requests that are commented.
-func (f *reviewPrFetcherImpl) CommentedPrs() ([]usecase.PullRequest, error) {
+func (f *reviewPrFetcherImpl) ReviewedPrs() ([]usecase.PullRequest, error) {
 	b, err := searchCommentedReviewPRCommand()
 	if err != nil {
 		return nil, fmt.Errorf("failed to search commented prs: %w", err)
@@ -40,23 +40,6 @@ func (f *reviewPrFetcherImpl) CommentedPrs() ([]usecase.PullRequest, error) {
 	var prs []usecase.PullRequest
 	if err := json.Unmarshal(b, &prs); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal commented prs: %w", err)
-	}
-
-	// TODO: review-requested な PR が含まれている場合は除外する
-
-	return prs, nil
-}
-
-// ChangesRequestedPrs returns a list of pull requests that are requested to change.
-func (f *reviewPrFetcherImpl) ChangesRequestedPrs() ([]usecase.PullRequest, error) {
-	b, err := searchChangesRequestedReviewPRCommand()
-	if err != nil {
-		return nil, fmt.Errorf("failed to search changes requested prs: %w", err)
-	}
-
-	var prs []usecase.PullRequest
-	if err := json.Unmarshal(b, &prs); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal changes requested prs: %w", err)
 	}
 
 	// TODO: review-requested な PR が含まれている場合は除外する
@@ -97,17 +80,6 @@ func searchUnReviewedPRCommand() ([]byte, error) {
 // - no-assignee: @me
 func searchCommentedReviewPRCommand() ([]byte, error) {
 	cmd := exec.Command("gh", "search", "prs", "--owner", "wantedly", "--state", "open", "--reviewed-by", "@me", "--review", "none", "--no-assignee", "@me", "--limit", "100", "--json", "url")
-	output, err := cmd.Output()
-	return output, err
-}
-
-// Search query:
-// - owner: wantedly
-// - state: open
-// - review: changes_requested
-// - reviewed-by: @me
-func searchChangesRequestedReviewPRCommand() ([]byte, error) {
-	cmd := exec.Command("gh", "search", "prs", "--owner", "wantedly", "--state", "open", "--review", "changes_requested", "--reviewed-by", "@me", "--limit", "100", "--json", "url")
 	output, err := cmd.Output()
 	return output, err
 }

--- a/query/type.go
+++ b/query/type.go
@@ -1,0 +1,9 @@
+package query
+
+type SearchQueryResponse struct {
+	Items []Item `json:"items"`
+}
+
+type Item struct {
+	HTMLURL string `json:"html_url"`
+}

--- a/usecase/mock/query_type_mock.go
+++ b/usecase/mock/query_type_mock.go
@@ -91,34 +91,19 @@ func (mr *MockPrFetcherMockRecorder) ApprovedPrs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApprovedPrs", reflect.TypeOf((*MockPrFetcher)(nil).ApprovedPrs))
 }
 
-// ChangesRequestedPrs mocks base method.
-func (m *MockPrFetcher) ChangesRequestedPrs() ([]usecase.PullRequest, error) {
+// ReviewedPrs mocks base method.
+func (m *MockPrFetcher) ReviewedPrs() ([]usecase.PullRequest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangesRequestedPrs")
+	ret := m.ctrl.Call(m, "ReviewedPrs")
 	ret0, _ := ret[0].([]usecase.PullRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ChangesRequestedPrs indicates an expected call of ChangesRequestedPrs.
-func (mr *MockPrFetcherMockRecorder) ChangesRequestedPrs() *gomock.Call {
+// ReviewedPrs indicates an expected call of ReviewedPrs.
+func (mr *MockPrFetcherMockRecorder) ReviewedPrs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangesRequestedPrs", reflect.TypeOf((*MockPrFetcher)(nil).ChangesRequestedPrs))
-}
-
-// ReviewRequestedPrs mocks base method.
-func (m *MockPrFetcher) ReviewRequestedPrs() ([]usecase.PullRequest, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReviewRequestedPrs")
-	ret0, _ := ret[0].([]usecase.PullRequest)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReviewRequestedPrs indicates an expected call of ReviewRequestedPrs.
-func (mr *MockPrFetcherMockRecorder) ReviewRequestedPrs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReviewRequestedPrs", reflect.TypeOf((*MockPrFetcher)(nil).ReviewRequestedPrs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReviewedPrs", reflect.TypeOf((*MockPrFetcher)(nil).ReviewedPrs))
 }
 
 // UnReviewedPrs mocks base method.
@@ -174,34 +159,19 @@ func (mr *MockReviewPrFetcherMockRecorder) ApprovedPrs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApprovedPrs", reflect.TypeOf((*MockReviewPrFetcher)(nil).ApprovedPrs))
 }
 
-// ChangesRequestedPrs mocks base method.
-func (m *MockReviewPrFetcher) ChangesRequestedPrs() ([]usecase.PullRequest, error) {
+// ReviewedPrs mocks base method.
+func (m *MockReviewPrFetcher) ReviewedPrs() ([]usecase.PullRequest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangesRequestedPrs")
+	ret := m.ctrl.Call(m, "ReviewedPrs")
 	ret0, _ := ret[0].([]usecase.PullRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ChangesRequestedPrs indicates an expected call of ChangesRequestedPrs.
-func (mr *MockReviewPrFetcherMockRecorder) ChangesRequestedPrs() *gomock.Call {
+// ReviewedPrs indicates an expected call of ReviewedPrs.
+func (mr *MockReviewPrFetcherMockRecorder) ReviewedPrs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangesRequestedPrs", reflect.TypeOf((*MockReviewPrFetcher)(nil).ChangesRequestedPrs))
-}
-
-// CommentedPrs mocks base method.
-func (m *MockReviewPrFetcher) CommentedPrs() ([]usecase.PullRequest, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CommentedPrs")
-	ret0, _ := ret[0].([]usecase.PullRequest)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CommentedPrs indicates an expected call of CommentedPrs.
-func (mr *MockReviewPrFetcherMockRecorder) CommentedPrs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommentedPrs", reflect.TypeOf((*MockReviewPrFetcher)(nil).CommentedPrs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReviewedPrs", reflect.TypeOf((*MockReviewPrFetcher)(nil).ReviewedPrs))
 }
 
 // UnReviewedPrs mocks base method.

--- a/usecase/pr_automation.go
+++ b/usecase/pr_automation.go
@@ -23,15 +23,10 @@ func NewPrAutomation(prFetcher PrFetcher, projectV2Setter ProjectV2Setter) domai
 
 // SetInProgress sets pull requests that are in progress.
 func (a *prAutomationImpl) SetInProgress() error {
-	unReviewedPrs, err := a.prFetcher.UnReviewedPrs()
+	prs, err := a.prFetcher.UnReviewedPrs()
 	if err != nil {
 		return fmt.Errorf("PRAutomation SetInProgress is failed: %w", err)
 	}
-	changesRequestedPrs, err := a.prFetcher.ChangesRequestedPrs()
-	if err != nil {
-		return fmt.Errorf("PRAutomation SetInProgress is failed: %w", err)
-	}
-	prs := append(unReviewedPrs, changesRequestedPrs...)
 
 	categoryID := variables.PR_CATEGORY_ID
 	statusID := variables.IN_PROGRESS_STATUS_ID
@@ -49,7 +44,7 @@ func (a *prAutomationImpl) SetInProgress() error {
 
 // SetInPending sets pull requests that are requested to review.
 func (a *prAutomationImpl) SetInPending() error {
-	prs, err := a.prFetcher.ReviewRequestedPrs()
+	prs, err := a.prFetcher.ReviewedPrs()
 	if err != nil {
 		return fmt.Errorf("PRAutomation SetInPending is failed: %w", err)
 	}

--- a/usecase/pr_automation_test.go
+++ b/usecase/pr_automation_test.go
@@ -24,7 +24,6 @@ func TestPrAutomationSetInProgress(t *testing.T) {
 
 	// Expected calls
 	mockPrFetcher.EXPECT().UnReviewedPrs().Return(expectedPRs, nil).Times(1)
-	mockPrFetcher.EXPECT().ChangesRequestedPrs().Return(expectedPRs, nil).Times(1)
 	mockProjectV2Setter.EXPECT().Set(variables.PR_CATEGORY_ID, variables.IN_PROGRESS_STATUS_ID, gomock.Any()).Return(nil).Times(1)
 
 	// Initialize the struct with mocks
@@ -54,7 +53,7 @@ func TestPrAutomationSetInPending(t *testing.T) {
 	}
 
 	// Expected calls
-	mockPrFetcher.EXPECT().ReviewRequestedPrs().Return(expectedPRs, nil).Times(1)
+	mockPrFetcher.EXPECT().ReviewedPrs().Return(expectedPRs, nil).Times(1)
 	mockProjectV2Setter.EXPECT().Set(variables.PR_CATEGORY_ID, variables.IN_PENDING_STATUS_ID, gomock.Any()).Return(nil).Times(1)
 
 	// Initialize the struct with mocks

--- a/usecase/query_type.go
+++ b/usecase/query_type.go
@@ -20,15 +20,13 @@ type IssueFetcher interface {
 // PrFetcher is an interface for fetching pull requests.
 type PrFetcher interface {
 	UnReviewedPrs() ([]PullRequest, error)
-	ChangesRequestedPrs() ([]PullRequest, error)
-	ReviewRequestedPrs() ([]PullRequest, error)
+	ReviewedPrs() ([]PullRequest, error)
 	ApprovedPrs() ([]PullRequest, error)
 }
 
 // ReviewPrFetcher is an interface for fetching pull requests that are requested to review.
 type ReviewPrFetcher interface {
 	UnReviewedPrs() ([]PullRequest, error)
-	CommentedPrs() ([]PullRequest, error)
-	ChangesRequestedPrs() ([]PullRequest, error)
+	ReviewedPrs() ([]PullRequest, error)
 	ApprovedPrs() ([]PullRequest, error)
 }

--- a/usecase/review_pr_automation.go
+++ b/usecase/review_pr_automation.go
@@ -42,17 +42,10 @@ func (a *reviewPrAutomation) SetInProgress() error {
 }
 
 func (a *reviewPrAutomation) SetInPending() error {
-	commentedPrs, err := a.reviewPrFetcher.CommentedPrs()
+	prs, err := a.reviewPrFetcher.ReviewedPrs()
 	if err != nil {
 		return fmt.Errorf("ReviewPRAutomation SetInPending is failed: %w", err)
 	}
-
-	changesRequestedPrs, err := a.reviewPrFetcher.ChangesRequestedPrs()
-	if err != nil {
-		return fmt.Errorf("ReviewPRAutomation SetInPending is failed: %w", err)
-	}
-
-	prs := append(commentedPrs, changesRequestedPrs...)
 
 	categoryID := variables.REVIEW_PR_CATEGORY_ID
 	statusID := variables.IN_PENDING_STATUS_ID

--- a/usecase/review_pr_automation_test.go
+++ b/usecase/review_pr_automation_test.go
@@ -53,8 +53,7 @@ func TestReviewPrAutomationSetInPending(t *testing.T) {
 	}
 
 	// Expected calls
-	mockPrFetcher.EXPECT().CommentedPrs().Return(expectedPRs, nil).Times(1)
-	mockPrFetcher.EXPECT().ChangesRequestedPrs().Return(expectedPRs, nil).Times(1)
+	mockPrFetcher.EXPECT().ReviewedPrs().Return(expectedPRs, nil).Times(1)
 	mockProjectV2Setter.EXPECT().Set(variables.REVIEW_PR_CATEGORY_ID, variables.IN_PENDING_STATUS_ID, gomock.Any()).Return(nil).Times(1)
 
 	// Initialize the struct with mocks


### PR DESCRIPTION
- Rename "ChangesRequestedPrs" to "ReviewedPrs" in prFetcherImpl and reviewPrFetcherImpl
- Refactor issue fetcher to use GitHub API for searching issuesThe commit refactors the `MyIssues` method in the `issueFetcherImpl` struct to use the GitHub API for searching issues instead of executing a command-line `gh` command. It also adds a new file `type.go` which defines the `SearchQueryResponse` and `Item` structs used for unmarshaling the API response
